### PR TITLE
Fix for review 3.

### DIFF
--- a/bowtie2-makefile-cxxflags.patch
+++ b/bowtie2-makefile-cxxflags.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile b/Makefile
+index 9b6a46e..df5a817 100644
+--- a/Makefile
++++ b/Makefile
+@@ -207,18 +207,18 @@ else ifeq (amd64,$(shell uname -m))
+ else ifeq (aarch64,$(shell uname -m))
+   BITS := 64
+   SSE_FLAG :=
+-  CXXFLAGS := -fopenmp-simd
+-  CPPFLAGS := -Ithird_party/simde
++  CXXFLAGS += -fopenmp-simd
++  CPPFLAGS += -Ithird_party/simde
+ else ifeq (s390x,$(shell uname -m))
+   BITS := 64
+   SSE_FLAG :=
+-  CXXFLAGS := -fopenmp-simd
+-  CPPFLAGS := -Ithird_party/simde
++  CXXFLAGS += -fopenmp-simd
++  CPPFLAGS += -Ithird_party/simde
+   SANITIZER_FLAGS :=
+ else ifeq (ppc64le,$(shell uname -m))
+   BITS := 64
+   SSE_FLAG :=
+-  CXXFLAGS := -fopenmp-simd
++  CXXFLAGS += -fopenmp-simd
+   CPPFLAGS += -Ithird_party/simde
+   SANITIZER_FLAGS :=
+ endif
+-- 
+2.25.4
+


### PR DESCRIPTION
This PR is to fix for 3rd time review by https://bugzilla.redhat.com/show_bug.cgi?id=1824348#c7 .

I converted the 2 lines blank to 1 line blank too.

Right now there are 2 issues.

First, `man bowtie2` prints `bowtie2-align-s` command while `bowtie2 --help` is okay.

```
$ man bowtie2
BOWTIE2-ALIGN-S(VERSION)       bowtie2-align-s version 2.4.1       BOWTIE2-ALIGN-S(VERSION)

NAME
       bowtie2-align-s version - manual page for bowtie2-align-s version 2.4.1
...
```

Second, it seems that build flags still not used in `Makefile` with `%set_build_flags`, as a result aarch64 build is failed.

https://kojipkgs.fedoraproject.org//work/tasks/3969/43833969/build.log

```
/usr/bin/ld: /tmp/cc9NcHHs.o: relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `_ZSt4cerr@@GLIBCXX_3.4' which may bind externally can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: /tmp/cc9NcHHs.o(.text+0x3e4): unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol `_ZSt4cerr@@GLIBCXX_3.4'
```
